### PR TITLE
Authenticated Volumes, TLS transport and Hostinfo Support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,4 +168,4 @@ DEPENDENCIES
   rest-client-components
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/exe/volumectl
+++ b/exe/volumectl
@@ -148,8 +148,12 @@ class CreateCommand < Command
     enum_check(val, %w(autovol autoclone snappy))
   end
   option '--user', 'USER', 'volume owner'
+  option '--access-token', 'TOKEN', 'API access token for user authentication'
   option '--capacity', 'CAPACITY', 'request volume capacity (bytes, N GiB, etc.)'
   option '--iops', 'IOPS', 'requested service IOPS'
+  option '--transport', 'TRANSPORT', 'requested transport (tls, insecure, etc.)' do |val|
+    enum_check(val, %w(tls insecure))
+  end
   option '--clone-basis', 'CLONE-BASIS', '(autoclone) clone basis disk'
   option '--snapshot-tag', 'SNAPSHOT-TAG', '(autoclone) clone basis disk snapshot tag'
   option '--snapshot-interval-hours', 'SNAPSHOT-INTERVAL-HOURS', '(snappy) take snapshot every interval'
@@ -164,8 +168,10 @@ class CreateCommand < Command
       h[:name]         = name 
       h[:type]         = type
       h[:user]         = user
+      h[:access_token] = access_token
       h[:capacity]     = capacity
       h[:iops]         = iops
+      h[:transport]    = transport
       h[:attributes]   = attributes.join(' ') if attributes.length > 0
       h[:clone_basis]  = clone_basis
       h[:snapshot_tag] = snapshot_tag
@@ -177,6 +183,7 @@ class CreateCommand < Command
   def volume_create_params
     create_params.tap { |h|
       h[:profile] = profile
+      h[:otp]     = otp
     }.reject { |_, v| v.nil? }
   end
 end
@@ -184,6 +191,7 @@ end
 class VolumeCreate < CreateCommand
   option '--name', 'VOLUME', 'volume name', :required => true
   option '--profile', 'PROFILE', 'storage profile'
+  option '--otp', 'OTP', 'one time password authentication'
   parameter '[ATTRIBUTES] ...', 'provisioning attributes (+tag to include, -tag to exclude)', :attribute_name => :attributes
 
   def exec
@@ -193,9 +201,17 @@ end
 
 class VolumeRemove < Command
   option '--name', 'VOLUME', 'volume name', :required => true
+  option '--otp', 'OTP', 'one time password authentication'
+
+  def volume_remove_params
+    Hash.new.tap { |h|
+      h[:name] = name
+      h[:otp]  = otp
+    }.reject { |_, v| v.nil? }
+  end
 
   def exec
-    volume_api.delete(name: name).body
+    volume_api.delete(volume_remove_params).body
   end
 end
 

--- a/volume_driver.rb
+++ b/volume_driver.rb
@@ -21,7 +21,8 @@ class VolumeDriver
     use Goliath::Rack::Params # parse & merge query and body parameters
 
     plugin Blockbridge::Config
-    plugin Blockbridge::VolumeMonitor
+    plugin Blockbridge::VolumeCacheMonitor
+    plugin Blockbridge::VolumeHostinfo
 
     # process api call
     def response(env)

--- a/volume_driver/apis.rb
+++ b/volume_driver/apis.rb
@@ -82,6 +82,16 @@ class VolumeType < Grape::Validations::Base
   end
 end
 
+class TransportType < Grape::Validations::Base
+  def validate_param!(attr_name, params)
+    unless params[attr_name] =~ /tls|insecure/
+      fail Grape::Exceptions::Validation,
+        params: [@scope.full_name(attr_name)],
+        message: "Must be one of 'tls', 'insecure'"
+    end
+  end
+end
+
 # Import support APIs
 require_rel 'apis/*.rb'
 
@@ -91,10 +101,12 @@ class API::VolumeDriver < Grape::API
   default_format :json
 
   rescue_from Grape::Exceptions::ValidationErrors do |e|
+    env.logger.info e.message.chomp.squeeze("\n")
     error!({ Err: e.message, validation_failures: e }, 400)
   end
 
   rescue_from Blockbridge::NotFound do |e|
+    env.logger.info e.message.chomp.squeeze("\n")
     error!({ Err: e.message }, 400)
   end
 
@@ -106,6 +118,7 @@ class API::VolumeDriver < Grape::API
   end
 
   rescue_from Blockbridge::ResourcesUnavailable do |e|
+    env.logger.info e.message.chomp.squeeze("\n")
     error!({ Err: e.message }, 400)
   end
 

--- a/volume_driver/apis/docker_plugin.rb
+++ b/volume_driver/apis/docker_plugin.rb
@@ -7,6 +7,7 @@ class API::DockerPlugin < Grape::API
 
   before do
     status 200
+    parse_params(params)
     start_iscsid
   end
 
@@ -21,11 +22,14 @@ class API::DockerPlugin < Grape::API
   resource 'VolumeDriver.Create' do
     desc "Create a Volume"
     params do
-      requires :Name,       type: String, desc: "Volume Name"
-      optional :Opts, type: Hash, desc: "Volume Options" do
-        optional :profile,      type: String,  desc: "volume profile"
+      requires :Name,       type: String, desc: 'Volume Name'
+      optional :Opts, type: Hash, desc: 'Volume Options' do
+        optional :profile,      type: String,  desc: 'volume profile'
         optional :type,         type: String,  desc: 'volume type', volume_type: true
         optional :user,         type: String,  desc: 'volume user (owner)'
+        optional :otp,          type: String,  desc: 'volume one time password (OTP)'
+        optional :transport,    type: String,  desc: 'specify transport security (tls, insecure)', transport_type: true
+        optional :access_token, type: String,  desc: 'API access token for user authentication'
         optional :capacity,     type: String,  desc: 'volume provisioning capacity'
         optional :iops,         type: Integer, desc: 'volume provisioning IOPS (QoS)'
         optional :attributes,   type: String,  desc: 'volume provisioning attributes'
@@ -49,7 +53,10 @@ class API::DockerPlugin < Grape::API
   resource 'VolumeDriver.Remove' do
     desc "Remove a Volume"
     params do
-      requires :Name, type: String, desc: "Volume Name"
+      requires :Name, type: String, desc: 'Volume Name'
+      optional :Opts, type: Hash, desc: 'Volume Options' do
+        optional :otp, type: String,  desc: 'volume one time password (OTP)'
+      end
     end
     post do
       synchronize do
@@ -63,6 +70,9 @@ class API::DockerPlugin < Grape::API
     desc "Mount a Volume"
     params do
       requires :Name, type: String, desc: "Volume Name"
+      optional :Opts, type: Hash, desc: 'Volume Options' do
+        optional :otp, type: String,  desc: 'volume one time password (OTP)'
+      end
     end
     post do
       synchronize do

--- a/volume_driver/apis/profile.rb
+++ b/volume_driver/apis/profile.rb
@@ -10,6 +10,8 @@ class API::Profile < Grape::API
     requires :name,         type: String,  desc: 'profile name'
     requires :user,         type: String,  desc: 'volume user (owner)'
     optional :type,         type: String,  desc: 'volume type', default: 'autovol', volume_type: true
+    optional :access_token, type: String,  desc: 'API access token for user authentication'
+    optional :transport,    type: String,  desc: 'specify transport security (tls, insecure)', transport_type: true
     optional :capacity,     type: String,  desc: 'volume capacity'
     optional :iops,         type: Integer, desc: 'volume provisioning IOPS (QoS)'
     optional :attributes,   type: String,  desc: 'volume attributes'

--- a/volume_driver/apis/volume.rb
+++ b/volume_driver/apis/volume.rb
@@ -11,6 +11,9 @@ class API::Volume < Grape::API
     optional :profile,      type: String,  desc: 'volume profile'
     optional :type,         type: String,  desc: 'volume type', volume_type: true
     optional :user,         type: String,  desc: 'volume user (owner)'
+    optional :otp,          type: String,  desc: 'volume one time password (OTP)'
+    optional :tls,          type: Boolean, desc: 'attach with TLS transport security'
+    optional :access_token, type: String,  desc: 'API access token for user authentication'
     optional :capacity,     type: String,  desc: 'volume capacity'
     optional :iops,         type: Integer, desc: 'volume provisioning IOPS (QoS)'
     optional :attributes,   type: String,  desc: 'volume attributes'
@@ -30,7 +33,7 @@ class API::Volume < Grape::API
 
   desc 'List all volumes'
   get do
-    body(volume_info)
+    body(volume_lookup_all)
   end
 
   route_param :name do

--- a/volume_driver/helpers.rb
+++ b/volume_driver/helpers.rb
@@ -15,6 +15,7 @@ require_rel 'helpers/*.rb'
 
 # Helpers
 module Helpers
+  include Helpers::Params
   include Helpers::Volume
   include Helpers::Profile
   include Helpers::DockerApi

--- a/volume_driver/helpers/blockbridge_api.rb
+++ b/volume_driver/helpers/blockbridge_api.rb
@@ -10,23 +10,30 @@ module Helpers
       @@bbapi_client ||= {}
     end
 
-    def bbapi_client_handle(user)
-      "#{access_token}:#{user}"
+    def bbapi_client_handle(user, user_token)
+      "#{access_token(user_token)}:#{user}"
     end
 
-    def access_token
-      @access_token ||= api_token
+    def access_token(user_token)
+      if user_token
+        user_token
+      else
+        system_access_token
+      end
     end
 
     def url
-      "https://#{api_host}/api" if api_host
-      api_url if api_url
+      if api_host
+        "https://#{api_host}/api"
+      elsif api_url
+        api_url
+      end
     end
 
-    def client_params(user)
+    def client_params(user, user_token)
       Hash.new.tap do |p|
         p[:user] = user || ''
-        if user
+        if user && user_token.nil?
           p[:default_headers] = {
             'X-Blockbridge-SU' => user,
           }
@@ -35,33 +42,56 @@ module Helpers
       end
     end
 
-    def bbapi(user = nil)
-      BlockbridgeApi.bbapi_client[bbapi_client_handle(user)] ||=
+    def bbapi(user = nil, user_token = nil)
+      BlockbridgeApi.bbapi_client[bbapi_client_handle(user, user_token)] ||=
         begin
           Blockbridge::Api::Client.defaults[:ssl_verify_peer] = false
-          Blockbridge::Api::Client.new_oauth(access_token, client_params(user))
+          Blockbridge::Api::Client.new_oauth(access_token(user_token),
+                                             client_params(user, user_token))
         end
     end
 
-    def bb_lookup(user, vol_name)
-      vols = bbapi(user).vdisk.list(label: vol_name)
+    def bb_lookup_vol(vol_name, user, user_token = nil)
+      vols = bbapi(user, user_token).vdisk.list(label: vol_name)
       raise Blockbridge::NotFound if vols.empty?
       vols.first
     end
 
-    def bb_remove(user, vol_name)
-      disk = bb_lookup(user, vol_name)
-      bbapi(user).objects.remove_by_xref("#{volume_ref_prefix}#{vol_name}", scope: "vdisk,xmd")
-      if bbapi(user).vdisk.list(vss_id: disk.vss_id).empty?
-        bbapi(user).vss.remove(disk.vss_id)
+    def bb_remove_vol(vol_name, user, user_token = nil)
+      vol = bb_lookup_vol(vol_name, user, user_token)
+      bbapi(user, user_token).objects.remove_by_xref("#{volume_ref_prefix}#{vol_name}", scope: "vdisk,xmd")
+      if bbapi(user, user_token).vdisk.list(vss_id: vol.vss_id).empty?
+        bbapi(user, user_token).vss.remove(vol.vss_id)
       end
     rescue Blockbridge::NotFound
     end
 
-    def bb_is_attached(user, vol_name)
-      disk = bb_lookup(user, vol_name)
-      disk.xmd_refs.any? { |x| x.start_with? "host-attach" }
-    rescue Blockbridge::NotFound
+    def bb_lookup_user(user)
+      raise Blockbridge::Notfound if bbapi.user_profile.list(login: user).length == 0
+    end
+
+    def bb_lookup_vol_info(vol)
+      bb_lookup_user(vol[:user])
+      info = bbapi.xmd.info("docker-volume-#{vol[:name]}")
+      info[:data].merge(info[:data][:volume])
+    rescue Excon::Errors::NotFound, Excon::Errors::Gone, Blockbridge::NotFound
+    end
+
+    def bb_host_attached(ref, user, user_token = nil)
+      bbapi(user, user_token).xmd.info(ref)
+    rescue Excon::Errors::NotFound
+    end
+
+    def bb_get_attached(vol_name, user, user_token = nil)
+      vol = bb_lookup_vol(vol_name, user, user_token)
+      attached = vol.xmd_refs.select { |x| x.start_with? "host-attach" }
+      return unless attached.length > 0
+      attached.map! { |ref|
+        bb_host_attached(ref, user, user_token)
+      }.compact!
+      return unless attached.length > 0
+      attached
+    rescue Blockbridge::NotFound, Excon::Errors::NotFound
     end
   end
 end

--- a/volume_driver/helpers/cache.rb
+++ b/volume_driver/helpers/cache.rb
@@ -27,7 +27,7 @@ module Helpers
         f.fsync rescue nil
       end
       File.rename(tmp_file, vol_cache_path(name))
-      Blockbridge::VolumeMonitor.cache.reset
+      Blockbridge::VolumeCacheMonitor.cache.reset
     rescue => e
       logger.info "vol_cache_add failed: #{e.message}"
     end

--- a/volume_driver/helpers/defs.rb
+++ b/volume_driver/helpers/defs.rb
@@ -13,7 +13,7 @@ module Helpers
     end
 
     def vol_name
-      @vol_name ||= params[:Name] || params[:name]
+      @vol_name ||= parse_params_name || params[:Name] || params[:name]
     end
 
     def profile_name
@@ -85,12 +85,12 @@ module Helpers
       File.join(volumes_root, name)
     end
 
-    def api_token_default
-      "default"
+    def access_token_default
+      "--unset-default--"
     end
 
-    def api_token
-      Blockbridge::Config.api_token || ENV['BLOCKBRIDGE_API_KEY'] || api_token_default
+    def system_access_token
+      Blockbridge::Config.access_token || ENV['BLOCKBRIDGE_API_KEY'] || access_token_default
     end
 
     def api_host
@@ -98,7 +98,7 @@ module Helpers
     end
 
     def api_url
-      if api_token != api_token_default
+      if system_access_token != access_token_default
         "https://#{api_host}/api"
       else
         "https://#{Resolv.getaddress(api_host)}:9999/api"
@@ -112,7 +112,7 @@ module Helpers
 
     def params_opts
       return params['Opts'].deep_symbolize_keys if params['Opts']
-      return params
+      return params.deep_symbolize_keys
     end
 
     def params_type

--- a/volume_driver/helpers/iscsid.rb
+++ b/volume_driver/helpers/iscsid.rb
@@ -17,7 +17,7 @@ module Helpers
     def stop_iscsid
       return unless Iscsid.iscsid
       Process.kill("TERM", Iscsid.iscsid)
-      Process.kill("KILL", Helpers::Iscsid.iscsid)
+      Process.kill("KILL", Iscsid.iscsid)
       Process.detach .iscsid
     end
 
@@ -33,11 +33,11 @@ module Helpers
       return if Iscsid.iscsid
       return if iscsid_running? 
 
-      Helpers::Iscsid.iscsid = POSIX::Spawn::spawn('/bb/bin/iscsid -f',
-                                                   :out=>["/tmp/iscsid.out.log", "w"],
-                                                   :err=>["/tmp/iscsid.err.log", "w"])
+      Iscsid.iscsid = POSIX::Spawn::spawn('/bb/bin/iscsid -f',
+                                          :out=>["/tmp/iscsid.out.log", "w"],
+                                          :err=>["/tmp/iscsid.err.log", "w"])
 
-      raise "Unable to start iscsid" unless Helpers::Iscsid.iscsid
+      raise "Unable to start iscsid" unless Iscsid.iscsid
     end
   end
 end

--- a/volume_driver/helpers/params.rb
+++ b/volume_driver/helpers/params.rb
@@ -1,0 +1,56 @@
+# Copyright (c) 2015-2016, Blockbridge Networks LLC.  All rights reserved.
+# Use of this source code is governed by a BSD-style license, found
+# in the LICENSE file.
+
+module Helpers
+  module Params
+    def self.volume_sessions
+      @@sessions ||= {}
+    end
+
+    def parse_params(params)
+      return unless params[:Name] && params[:Name].include?('=')
+      params[:Opts] ||= {}
+
+      # find leading 'name(,key=val...)'
+      params[:Name].scan(/(\A[^,]+)/) do |val|
+        next if val[0].include?('=')
+        params[:Opts][:name] = val[0]
+      end
+
+      # find 'key=val(,key=val...)
+      params[:Name].sub(/\A#{params[:Opts][:name]},/, '').scan(/([^=,]+)=([^=,]+)/) do |key, val|
+        params[:Opts][key.to_sym] = val
+      end
+
+      pp params
+    end
+
+    def parse_params_name
+      return unless params[:Name] && params[:Name].include?('=')
+      return params[:Opts][:name] if params[:Opts]
+    end
+
+    def params_name
+      return params[:Name]
+    end
+
+    def session_token_valid?(otp)
+      return unless Params.volume_sessions[vol_name]
+      return unless Params.volume_sessions[vol_name][:otp] == otp
+      true
+    end
+
+    def get_session_token(otp)
+      return unless session_token_valid?(otp)
+      Params.volume_sessions[vol_name][:token]
+    end
+
+    def set_session_token(otp, token)
+      Params.volume_sessions[vol_name] = {
+        otp: otp,
+        token: token,
+      }
+    end
+  end
+end

--- a/volume_driver/helpers/profile.rb
+++ b/volume_driver/helpers/profile.rb
@@ -6,7 +6,7 @@ module Helpers
   module Profile
     def profile_env
       env = { 
-        "BLOCKBRIDGE_API_KEY"        => api_token,
+        "BLOCKBRIDGE_API_KEY"        => system_access_token,
         "BLOCKBRIDGE_API_HOST"       => api_host,
         "BLOCKBRIDGE_API_URL"        => api_url,
       }

--- a/volume_driver/plugins/config.rb
+++ b/volume_driver/plugins/config.rb
@@ -9,8 +9,8 @@ module Blockbridge
     attr_reader :logger
     attr_reader :status
 
-    def self.api_token
-      @@api_token
+    def self.access_token
+      @@access_token
     end
 
     def self.api_host
@@ -21,18 +21,18 @@ module Blockbridge
       @config = config
       @logger = logger
       @status = status
-      @@api_token = nil
+      @@access_token = nil
       @@api_host = nil
     end
 
     def run
-      return if api_token != api_token_default
+      return if system_access_token != access_token_default
       logger.debug "Configuring authentication"
       net = bbapi.net.list({}).first
       return unless net[:nat_addr]
       authz = bbapi.authorization.create({})
       status = bbapi.status.authorization
-      @@api_token = authz[:access_token]
+      @@access_token = authz[:access_token]
       @@api_host  = net[:nat_addr]
     rescue => e
       msg = e.message.chomp.squeeze("\n")

--- a/volume_driver/plugins/hostinfo.rb
+++ b/volume_driver/plugins/hostinfo.rb
@@ -1,0 +1,261 @@
+# Copyright (c) 2015-2016, Blockbridge Networks LLC.  All rights reserved.  Use
+# of this source code is governed by a BSD-style license, found in the LICENSE
+# file.
+
+module Blockbridge
+  class VolumeHostinfo
+    include Helpers
+    attr_reader :config
+    attr_reader :logger
+    attr_reader :status
+
+    def initialize(address, port, config, status, logger)
+      @config = config
+      @logger = logger
+      @status = status
+    end
+
+    def monitor_interval_s
+      ENV['BLOCKBRIDGE_HOSTINFO_INTERVAL_S'] || 10
+    end
+
+    def run
+      EM::Synchrony.run_and_add_periodic_timer(monitor_interval_s, &method(:volume_hostinfo_run))
+    end
+
+    def volume_host_info_map(xmd)
+      xmd[:data][:hostinfo]
+    end
+
+    def volume_host_info_lookup(vol, vol_info)
+      xmd = bbapi(vol[:user], vol_info[:scope_token]).xmd.info(vol_host_ref(vol[:name])) rescue nil
+      return volume_host_info_map(xmd) unless xmd.nil?
+    end
+
+    def volume_host_info_create(vol, vol_info)
+      vol_host_info = volume_host_info_lookup(vol, vol_info)
+      return vol_host_info if vol_host_info
+
+      params = {
+        ref: vol_host_ref(vol[:name]),
+        xref: volume_ref_name(vol[:name]),
+        data: {
+          hostinfo: {
+            :_schema => "terminal",
+            :data    => {
+              ongoing: false,
+              css: {
+                'min-height' => '25px',
+              },
+              lines: (hostinfo = volume_host_info_build(vol, vol_info)) ? hostinfo : [ "Not Attached." ],
+            },
+          },
+        },
+      }
+      xmd = bbapi(vol[:user], vol_info[:scope_token]).xmd.create(params)
+      volume_host_info_map(xmd)
+    rescue Blockbridge::Api::ConflictError
+    end
+
+    def disk_attach_host(x)
+      x[:data][:attach][:data][:host]
+    end
+
+    def disk_attach_mode(x)
+      return x[:mode] if x[:mode]
+      x[:data][:attach][:data][:mode]
+    rescue
+      'unknown'
+    end
+
+    def disk_attach_mode_str(x)
+      mode = disk_attach_mode(x)
+      case mode
+      when 'wo'
+        'write-only'
+      when 'rw'
+        'read-write'
+      when 'ro'
+        'read-only'
+      else
+        'unknown'
+      end
+    end
+
+    def disk_attach_transport_str(x)
+      return 'TCP/IP' unless x.data.attach.data.secure
+      x.data.attach.data.secure
+    rescue
+      'TCP/IP'
+    end
+
+    def volume_options_include
+      [
+        :capacity,
+        :iops,
+        :attributes,
+        :clone_basis,
+        :type,
+      ]
+    end
+
+    def volume_host_info_build_volume(vol, vol_info, attach_xmd)
+      # top-level volume
+      info = [
+        "Docker volume      #{vol[:name]}",
+      ]
+
+      # volume attachment
+      if attach_xmd
+        info.concat [
+          "Attached to        #{disk_attach_host(attach_xmd)}",
+          "Mode               #{disk_attach_mode_str(attach_xmd)}",
+          "Transport          #{disk_attach_transport_str(attach_xmd)}",
+        ]
+      else
+        info.concat [
+          "Attached to        -Not Attached-"
+        ]
+      end
+
+      # volume options
+      volume_options_include.each do |k|
+        info.push "#{k.to_s.downcase.capitalize.ljust(18)} #{vol_info[k]}" if vol_info[k]
+      end
+
+      info
+    end
+
+    def volume_host_info_build_fs(vol, vol_info, attach_xmd)
+      return [] unless attach_xmd
+      info = []
+      cmd = ['/bb/bin/nsexec', '/ns-mnt/mnt', 'df', '-kTh', mnt_path(vol[:name])]
+      res = cmd_exec_raw(*cmd, {})
+
+      res.each_line do |l|
+        next if l =~ /Filesystem/
+        md = /^(?<filesystem>.*?)\s+(?<type>.*?)\s+(?<size>.*?)\s+(?<used>.*?)\s+(?<avail>.*?)\s+(?<use_percent>.*?)\s+(?<mounted>.*)/.match(l)
+        next unless md && md[:mounted] == mnt_path(vol[:name])
+        fsinfo = [
+          "Filesystem         #{md[:filesystem]}",
+          "Type               #{md[:type]}",
+          "Size               #{md[:size]}",
+          "Used               #{md[:used]}",
+          "Available          #{md[:avail]}",
+          "Used%              #{md[:use_percent]}",
+          "Mounted on         #{md[:mounted]}",
+        ]
+        info.push ""
+        info.concat fsinfo
+      end
+      info
+    rescue Blockbridge::CommandError
+      []
+    end
+
+    def container_mounts_volume?(c, vol)
+      c.info['Mounts'].each do |m|
+        return true if m['Source'] == mnt_path(vol[:name])
+      end
+      false
+    end
+
+    def volume_host_info_build_docker(vol, vol_info)
+      info = []
+      defer do
+        params = {
+          all: true,
+        }
+        Docker::Container.all(params).each do |c|
+          next unless container_mounts_volume?(c, vol)
+
+          cinfo = [
+            "Container ID       #{c.id[0..12]}",
+            "Name               #{c.info['Names'].first[1..100]}",
+            "Host               #{ENV['HOSTNAME']}",
+            "Image              #{c.info['Image']}",
+            "Command            #{c.info['Command']}",
+            "State              #{c.info['State']}",
+            "Status             #{c.info['Status']}",
+          ]
+
+          info.push ""
+          info.concat cinfo
+
+          c.info['Mounts'].each do |m|
+            next unless m['Source'] == mnt_path(vol[:name])
+            minfo = [
+              "Mount Propagation  #{m['Propagation']}",
+              "Mounted on         #{m['Destination']}",
+            ]
+
+            info.concat minfo
+          end
+        end
+      end
+
+      info.push ""
+      info
+    end
+
+    def volume_host_info_build(vol, vol_info, vol_host_info = nil, attach_xmd = nil)
+      info = []
+      info.concat volume_host_info_build_volume(vol, vol_info, attach_xmd)
+      info.concat volume_host_info_build_fs(vol, vol_info, attach_xmd)
+      info.concat volume_host_info_build_docker(vol, vol_info)
+
+      return info unless (vol_host_info && vol_host_info.data.lines == info)
+    end
+
+    def volume_host_info_display_height(hostinfo)
+      return "25px" unless hostinfo.length > 0
+      length = hostinfo.length * 18 
+      "#{(450..length).min || length}px"
+    end
+
+    def volume_host_info_update(vol, vol_info)
+      vol_host_info = volume_host_info_create(vol, vol_info)
+      xmd = bb_get_attached(vol[:name], vol[:user], vol_info[:scope_token])
+      if xmd && (attach_xmd = xmd.first)
+        # attached
+        return unless disk_attach_host(attach_xmd) == ENV['HOSTNAME']
+      else
+        # detached
+        return unless (vol_host_info.data.host.nil? ||
+                       (vol_host_info.data.host == ENV['HOSTNAME']))
+      end
+
+      # build failed ; or no update required
+      return unless (hostinfo = volume_host_info_build(vol, vol_info, vol_host_info, attach_xmd))
+
+      # push a hostinfo update
+      params = {
+        mode: 'patch',
+        data: [ { op: 'add', path: '/hostinfo/data/lines',
+                  value: hostinfo },
+                { op: 'add', path: '/hostinfo/data/host',
+                  value: ENV['HOSTNAME'] },
+                { op: 'add', path: '/hostinfo/data/ongoing',
+                  value: attach_xmd ? true : false },
+                { op: 'add', path: '/hostinfo/data/css',
+                  value: { 'min-height' => "#{volume_host_info_display_height(hostinfo)}" } } ]
+      }
+      bbapi(vol[:user], vol_info[:scope_token]).xmd.update(vol_host_ref(vol[:name]), params)
+    end
+
+    def volume_hostinfo
+      vol_cache_foreach do |v, vol|
+        next unless (vol_info = bb_lookup_vol_info(vol))
+        volume_host_info_update(vol, vol_info)
+      end
+    end
+
+    def volume_hostinfo_run
+      volume_hostinfo
+    rescue => e
+      msg = e.message.chomp.squeeze("\n")
+      msg.each_line do |m| logger.error "hostinfo: #{m.chomp}" end
+      e.backtrace.each do |b| logger.error(b) end
+    end
+  end
+end

--- a/volume_driver/version.rb
+++ b/volume_driver/version.rb
@@ -4,6 +4,6 @@
 
 module Blockbridge
   module VolumeDriverVersion
-    VERSION = '3.2'
+    VERSION = '3.3'
   end
 end


### PR DESCRIPTION
Authenticated volumes require a one-time password (OTP) to be entered in order
to create a volume, mount a volume, or remove a volume. If the OTP is not
entered, the volume operation is denied. This functionality is supported using
standard Docker commands and API calls. Enable authenticated volumes in a
Storage Profile or inline by configuring the volume's user to require OTP.

TLS transport volume support secures the transport used to attach the volume to
the host via TLSv1.2. Configure the volume by specifying "transport=tls" in the
volume options, inline or in Storage Profiles. The network attached (iSCSI)
volume will be secured over TLS directly to the storage target.

Hostinfo support provides metadata about the volume, pushed to the Blockbridge
management control plane. Information such as the volume options, volume type,
filesystem statistics for the volume, the host it is attached to, the Docker
containers that are using the volume, are all presented in the management
interface for the volume.
