### PR TITLE
Support user scoped token for API authorization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # Use of this source code is governed by a BSD-style license, found
 # in the LICENSE file.
 
-VERSION_LEVEL  ?= 3.1
-VERSION_PATCH  ?= v2
+VERSION_LEVEL  ?= 4.3
+VERSION_PATCH  ?= v1
 VERSION         = $(VERSION_LEVEL)-$(VERSION_PATCH)
-REGISTRY       ?= 
+REGISTRY       ?=
 NAMESPACE       = blockbridge
 PLUGIN_NAME     = volume-plugin
 PLUGIN_REPO     = $(REGISTRY)$(NAMESPACE)/$(PLUGIN_NAME)

--- a/config.json
+++ b/config.json
@@ -73,8 +73,24 @@
       "value": "1"
     },
     {
+      "name": "BLOCKBRIDGE_LOGGER_TIMESTAMP",
+      "description": "prefix log messages with a timestamp",
+      "value": "0",
+      "Settable": [
+        "value"
+      ]
+    },
+    {
+      "name": "BLOCKBRIDGE_GLOBAL_TOKEN",
+      "description": "api key specified is global token; set to 1 to SU to users with one token",
+      "value": "0",
+      "Settable": [
+        "value"
+      ]
+    },
+    {
       "name": "BLOCKBRIDGE_API_HOST",
-      "description": "blockbridge api host (management node)",
+      "description": "blockbridge api host (controlplane)",
       "value": "unset",
       "Settable": [
         "value"

--- a/volume_driver.rb
+++ b/volume_driver.rb
@@ -54,11 +54,21 @@ class VolumeDriver
   class Logger < Log4r::Logger
     def initialize(name)
       super(name)
-      pattern = "%d %-7l %c -- %m\n"
-      datefmt = "%Y-%m-%dT%H:%M:%S.%3N"
-      format  = Log4r::PatternFormatter.new(pattern: pattern, date_pattern: datefmt)
-      stdout  = Log4r::StdoutOutputter.new('console', :formatter => format)
+      if logger_timestamp == "1"
+        pattern = "%d %-7l %c -- %m\n"
+        datefmt = "%Y-%m-%dT%H:%M:%S.%3N"
+        format  = Log4r::PatternFormatter.new(pattern: pattern, date_pattern: datefmt)
+        stdout  = Log4r::StdoutOutputter.new('console', :formatter => format)
+      else
+        pattern = "%-7l %c -- %m\n"
+        format  = Log4r::PatternFormatter.new(pattern: pattern)
+        stdout  = Log4r::StdoutOutputter.new('console', :formatter => format)
+      end
       add(stdout)
+    end
+
+    def logger_timestamp
+      ENV['BLOCKBRIDGE_LOGGER_TIMESTAMP'] || "1"
     end
   end
 

--- a/volume_driver/helpers/defs.rb
+++ b/volume_driver/helpers/defs.rb
@@ -95,7 +95,13 @@ module Helpers
     end
 
     def system_access_token
+      return unless ENV['BLOCKBRIDGE_GLOBAL_TOKEN'] == "1"
       Blockbridge::Config.access_token || ENV['BLOCKBRIDGE_API_KEY'] || access_token_default
+    end
+
+    def user_access_token
+      return if ENV['BLOCKBRIDGE_GLOBAL_TOKEN'] == "1"
+      ENV['BLOCKBRIDGE_API_KEY'] || access_token_default
     end
 
     def api_host

--- a/volume_driver/helpers/profile.rb
+++ b/volume_driver/helpers/profile.rb
@@ -16,8 +16,10 @@ module Helpers
       logger.info "#{vol_name} profile creating..."
 
       # ensure user exists
-      user = bbapi(nil, nil).user_profile.list(login: params[:user])&.first
-      raise Blockbridge::NotFound unless user
+      unless user_access_token
+        user = bbapi(nil, nil).user_profile.list(login: params[:user])&.first
+        raise Blockbridge::NotFound unless user
+      end
 
       # create profile
       data = Hash.new.tap do |h|

--- a/volume_driver/helpers/volume.rb
+++ b/volume_driver/helpers/volume.rb
@@ -80,6 +80,7 @@ module Helpers
     def volume_user
       return unless defined? params
       return if env['REQUEST_URI'].start_with? '/profile'
+      return if user_access_token
       @volume_user ||=
         begin
           raise Blockbridge::NotFound, "No volume user found (and no default profile?); specify user or volume profile" if volume_params[:user].nil?
@@ -295,8 +296,11 @@ module Helpers
           token = get_session_token(otp)
         else
           if volume_params[:access_token]
-            # login otp with user access token
+            # login otp with volume access token
             bbapi(nil, volume_params[:access_token], otp)
+          elsif user_access_token
+            # login otp with user access token
+            bbapi(nil, user_access_token, otp)
           else
             # login otp with system token and SU
             bbapi(volume_user, system_access_token, otp)
@@ -306,6 +310,8 @@ module Helpers
       else
         if volume_params[:access_token]
           token = volume_params[:access_token]
+        elsif user_access_token
+          token = user_access_token
         else
           token = system_access_token
         end

--- a/volume_driver/plugins/config.rb
+++ b/volume_driver/plugins/config.rb
@@ -30,6 +30,7 @@ module Blockbridge
       logger.debug "Configuring authentication"
       net = bbapi.net.list({}).first
       return unless net[:nat_addr]
+      return unless bbapi.status.authorization&.dig('permissions','user','rights','manage_authorizations')
       authz = bbapi.authorization.create({})
       status = bbapi.status.authorization
       @@access_token = authz[:access_token]


### PR DESCRIPTION
Bump version to version 4.3.

Allow specifying the BLOCKBRIDGE_API_KEY as a user-scoped token, that
does not require system global access. If the token specified *is*
a global "system" token, then specify BLOCKBRIDGE_GLOBAL_TOKEN="1" to
change the mode of operation.

With a user scoped token, no "user" is required when creating a volume
or a profile. All volumes are and state are kept per-user. To use
different users, use different volume plugins.

Includes the following changes:

* provision with "user" api token by default
* rev version to v4.3
* volume_user not required for user_access_token
* Create new scoped authorizations only if specified token allows it
* cache lookup vol info respects when no "user" is specified
* don't lookup or use "user" in api or profile if user_access_token
* conditionally prefix log messages with a timestamp